### PR TITLE
Add Inspired Nexus page

### DIFF
--- a/inspired.html
+++ b/inspired.html
@@ -1,0 +1,343 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Inspired Nexus</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link href="https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@400;500;700&display=swap" rel="stylesheet" />
+    <style>
+        :root {
+            color-scheme: dark;
+            --bg-gradient: linear-gradient(135deg, #0d0b1f 0%, #1d0f44 50%, #09384f 100%);
+            --accent: #7ddfff;
+            --accent-2: #ff82e6;
+            --text: #e9f7ff;
+            --glass: rgba(13, 17, 37, 0.65);
+            --glass-border: rgba(125, 223, 255, 0.35);
+        }
+
+        * {
+            box-sizing: border-box;
+            margin: 0;
+            padding: 0;
+        }
+
+        body {
+            font-family: "Space Grotesk", system-ui, sans-serif;
+            background: var(--bg-gradient);
+            color: var(--text);
+            min-height: 100vh;
+            display: flex;
+            flex-direction: column;
+        }
+
+        .hero {
+            position: relative;
+            padding: clamp(3rem, 5vw, 5rem) clamp(1.5rem, 6vw, 6rem);
+            overflow: hidden;
+        }
+
+        .hero::before,
+        .hero::after {
+            content: "";
+            position: absolute;
+            width: 45vw;
+            max-width: 520px;
+            aspect-ratio: 1/1;
+            background: radial-gradient(circle at center, rgba(125, 223, 255, 0.45) 0%, rgba(125, 223, 255, 0) 70%);
+            filter: blur(0.4rem);
+            z-index: 0;
+        }
+
+        .hero::before {
+            top: -18%;
+            right: -8%;
+        }
+
+        .hero::after {
+            bottom: -25%;
+            left: -12%;
+            background: radial-gradient(circle at center, rgba(255, 130, 230, 0.45) 0%, rgba(255, 130, 230, 0) 70%);
+        }
+
+        header {
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            gap: 1.5rem;
+            position: relative;
+            z-index: 1;
+            margin-bottom: clamp(3rem, 5vw, 5rem);
+        }
+
+        header h1 {
+            font-size: clamp(2.2rem, 6vw, 4rem);
+            letter-spacing: 0.02em;
+        }
+
+        .pulse {
+            position: relative;
+            display: inline-flex;
+            align-items: center;
+            gap: 0.6rem;
+            background: rgba(125, 223, 255, 0.08);
+            border: 1px solid rgba(125, 223, 255, 0.3);
+            border-radius: 999px;
+            padding: 0.6rem 1.1rem;
+            font-size: 0.9rem;
+            text-transform: uppercase;
+            letter-spacing: 0.2em;
+        }
+
+        .pulse::before {
+            content: "";
+            width: 0.75rem;
+            height: 0.75rem;
+            border-radius: 50%;
+            background: var(--accent);
+            box-shadow: 0 0 0.5rem rgba(125, 223, 255, 0.8);
+            animation: pulse 2s infinite;
+        }
+
+        @keyframes pulse {
+            0% { transform: scale(0.9); opacity: 0.8; }
+            50% { transform: scale(1.2); opacity: 0.2; }
+            100% { transform: scale(0.9); opacity: 0.8; }
+        }
+
+        .intro {
+            max-width: 760px;
+            font-size: clamp(1.05rem, 2.2vw, 1.35rem);
+            line-height: 1.65;
+            letter-spacing: 0.03em;
+            position: relative;
+            z-index: 1;
+        }
+
+        .grid {
+            display: grid;
+            grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+            gap: clamp(1.5rem, 3vw, 2.6rem);
+            padding: 0 clamp(1.5rem, 6vw, 6rem) clamp(4rem, 6vw, 6rem);
+        }
+
+        .card {
+            position: relative;
+            padding: 2.2rem 2rem;
+            border-radius: 1.5rem;
+            background: var(--glass);
+            border: 1px solid var(--glass-border);
+            box-shadow: 0 18px 40px rgba(5, 12, 32, 0.35);
+            overflow: hidden;
+            transition: transform 320ms ease, border-color 320ms ease;
+        }
+
+        .card::before {
+            content: "";
+            position: absolute;
+            inset: -60% 20% auto 20%;
+            height: 120%;
+            background: linear-gradient(135deg, rgba(125, 223, 255, 0.4), rgba(255, 130, 230, 0.15));
+            filter: blur(60px);
+            opacity: 0;
+            transition: opacity 320ms ease;
+        }
+
+        .card:hover {
+            transform: translateY(-8px) scale(1.01);
+            border-color: rgba(255, 130, 230, 0.55);
+        }
+
+        .card:hover::before {
+            opacity: 1;
+        }
+
+        .card h2 {
+            font-size: 1.5rem;
+            margin-bottom: 0.8rem;
+        }
+
+        .card p {
+            font-size: 1rem;
+            line-height: 1.6;
+            opacity: 0.9;
+        }
+
+        .card ul {
+            margin-top: 1.4rem;
+            display: grid;
+            gap: 0.6rem;
+            list-style: none;
+        }
+
+        .card a {
+            display: inline-flex;
+            align-items: center;
+            gap: 0.45rem;
+            color: var(--accent);
+            text-decoration: none;
+            font-size: 0.95rem;
+            letter-spacing: 0.01em;
+            transition: color 200ms ease;
+        }
+
+        .card a:hover {
+            color: var(--accent-2);
+        }
+
+        .card svg {
+            width: 1em;
+            height: 1em;
+        }
+
+        .marquee {
+            position: relative;
+            margin: clamp(2.5rem, 5vw, 4rem) 0;
+            padding: 1rem 0;
+            overflow: hidden;
+            border-block: 1px solid rgba(125, 223, 255, 0.25);
+            backdrop-filter: blur(12px);
+        }
+
+        .marquee-track {
+            display: flex;
+            gap: 3rem;
+            width: max-content;
+            animation: marquee 22s linear infinite;
+        }
+
+        .marquee span {
+            text-transform: uppercase;
+            letter-spacing: 0.4em;
+            font-size: 0.85rem;
+            opacity: 0.7;
+            white-space: nowrap;
+        }
+
+        @keyframes marquee {
+            to { transform: translateX(-50%); }
+        }
+
+        footer {
+            margin-top: auto;
+            padding: clamp(2rem, 4vw, 3rem);
+            text-align: center;
+            font-size: 0.85rem;
+            letter-spacing: 0.08em;
+            opacity: 0.8;
+        }
+
+        @media (max-width: 600px) {
+            header {
+                flex-direction: column;
+                text-align: center;
+            }
+
+            .pulse {
+                font-size: 0.8rem;
+            }
+        }
+    </style>
+</head>
+<body>
+    <section class="hero">
+        <header>
+            <div>
+                <p class="pulse">Inspired by the Lab</p>
+                <h1>Inspired Nexus</h1>
+            </div>
+            <nav>
+                <a class="pulse" style="gap:0.3rem; background: rgba(255, 130, 230, 0.12); border-color: rgba(255, 130, 230, 0.3);" href="index.html">Return to Hub</a>
+            </nav>
+        </header>
+        <p class="intro">
+            This page stitches together the explorations scattered across the site. From AI playgrounds and immersive 3D experiments to data visualizations and creative utilities, it is a pulse-check on everything built so far. Each capsule below pulls energy from a different corner of the lab—dive in, remix, and follow the threads.
+        </p>
+    </section>
+
+    <div class="marquee" aria-hidden="true">
+        <div class="marquee-track">
+            <span>AI Dialogues</span>
+            <span>Generative Art</span>
+            <span>3D Simulations</span>
+            <span>Interactive Dashboards</span>
+            <span>Spatial Audio</span>
+            <span>Utility Builders</span>
+            <span>AI Dialogues</span>
+            <span>Generative Art</span>
+            <span>3D Simulations</span>
+            <span>Interactive Dashboards</span>
+            <span>Spatial Audio</span>
+            <span>Utility Builders</span>
+        </div>
+    </div>
+
+    <section class="grid">
+        <article class="card">
+            <h2>Conversational Intelligence</h2>
+            <p>Inspired by the constellation of chat experiments, this capsule curates the expressive interfaces built for dialogue and assistance.</p>
+            <ul>
+                <li><a href="chatbotmax.html">Chatbot Max</a></li>
+                <li><a href="chat.html">Classic Chat Canvas</a></li>
+                <li><a href="Aichathelp.html">AI Chat Help Desk</a></li>
+            </ul>
+        </article>
+
+        <article class="card">
+            <h2>Immersive Worlds</h2>
+            <p>Borrowing from the 3D market, diamond simulations, and labyrinths, explore portals crafted for spatial storytelling.</p>
+            <ul>
+                <li><a href="3dmarketplace.html">3D Marketplace</a></li>
+                <li><a href="DIAMOND-Simulation.html">Diamond Simulation</a></li>
+                <li><a href="Labyrinth.html">Labyrinth Generator</a></li>
+            </ul>
+        </article>
+
+        <article class="card">
+            <h2>Creative Tools</h2>
+            <p>A collage of instruments that remix visuals, code, and sound—each one an invitation to craft something original.</p>
+            <ul>
+                <li><a href="Animation-Builder.html">Animation Builder</a></li>
+                <li><a href="Algorithmpatterngeneration.html">Pattern Generator</a></li>
+                <li><a href="unicodeaudiovisulizer.html">Unicode Audio Visualizer</a></li>
+            </ul>
+        </article>
+
+        <article class="card">
+            <h2>Data &amp; Dashboards</h2>
+            <p>Inspired by dashboards, search utilities, and planners that illuminate complex systems with clarity and motion.</p>
+            <ul>
+                <li><a href="dashboard.html">Mission Dashboard</a></li>
+                <li><a href="TaskmanagerBETA.html">Task Manager</a></li>
+                <li><a href="pagemaker.html">Page Maker Lab</a></li>
+            </ul>
+        </article>
+
+        <article class="card">
+            <h2>Futures &amp; Research</h2>
+            <p>Tracing the speculative tech timelines, hybrid networks, and quantum concepts that run through the archive.</p>
+            <ul>
+                <li><a href="Multi-Agent-Ontoverse.html">Ontoverse</a></li>
+                <li><a href="quantum-nexus.html">Quantum Nexus</a></li>
+                <li><a href="PROJECT1X4G-PAPER2025.html">Project 1X4G Paper</a></li>
+            </ul>
+        </article>
+
+        <article class="card">
+            <h2>Arcade Corner</h2>
+            <p>Pulling from playful experiments—mini-games and simulators that keep the lab’s heart curious and restless.</p>
+            <ul>
+                <li><a href="flappybird.html">AI Flappy Bird</a></li>
+                <li><a href="animalsim.html">Animal Simulator</a></li>
+                <li><a href="boxingai.html">Boxing AI</a></li>
+            </ul>
+        </article>
+    </section>
+
+    <footer>
+        Living index of everything built, remixed, and still in beta. Keep exploring.
+    </footer>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add an Inspired Nexus landing page that celebrates the variety of projects on the site
- highlight themed capsules that link out to representative experiences like chats, 3D spaces, creative tools, dashboards, research, and arcade experiments
- design a modern neon-glass style layout with animated marquee and responsive grid

## Testing
- no automated tests were run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68cdc804e9908331880f154cd342955f